### PR TITLE
Add support for proper task retries

### DIFF
--- a/sample/plugin.dig
+++ b/sample/plugin.dig
@@ -11,6 +11,7 @@ _export:
       - com.github.platform-lunar:digdag-plugin-livy:0.1.1
 
 +livy_action:
+  _retry: 2
   <<: *spark_defaults
   livy>: livy application test
   livy:


### PR DESCRIPTION
Without suffixing states with retry count we would only retry
initial Livy task state fetching which would non-surprisingly
result in `dead`. We would retry it `_retry` amount of times
without actually resubmitting the task (which is the intended
retry mechanism). This `retry_count` suffix addition enables
task resubmittion when retrying.

@yanrym @jarutis @ramasLTU